### PR TITLE
indicate the requirements for courses build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ HTML et PDF construits automatiquement :
 
 ## Prérequis
 
+### Option 1 : Utiliser le Makefile
+
 * make : <https://www.gnu.org/software/make/>
 * jq : <https://github.com/stedolan/jq>
-* Docker : <https://docs.docker.com/install>
 * pandoc : <https://pandoc.org>
 * TeX Live : <https://www.tug.org/texlive/>
+
+### Option 2 : Utiliser le script build.sh
+
+* Docker : <https://docs.docker.com/install>
 
 ## Fonctionnement
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ HTML et PDF construits automatiquement :
 * [Support HTML OpenStack Admin](https://osones.com/formations/openstack.fr.html)
 * [Support HTML Docker](https://osones.com/formations/docker.fr.html)
 
+## Prérequis
+
+* make : <https://www.gnu.org/software/make/>
+* jq : <https://github.com/stedolan/jq>
+* Docker : <https://docs.docker.com/install>
+* pandoc : <https://pandoc.org>
+* TeX Live : <https://www.tug.org/texlive/>
+
 ## Fonctionnement
 
 Les supports de formation (slides) sont écrits en Markdown. Chaque fichier dans `cours/` est un module indépendant.


### PR DESCRIPTION
It's not obvious for the basic user to know exactly what are the tools needed for build the courses in pdf and html. Some indications are present in the Makefile but there are only oriented to a specific Linux Distribution. 