### PR TITLE
add markdownlint configuration file and style (.ie set of rules)

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "test/mdl-style-formations.rb"

--- a/test/mdl-style-formations.rb
+++ b/test/mdl-style-formations.rb
@@ -1,0 +1,12 @@
+rule 'MD004'
+rule 'MD005'
+rule 'MD009', :br_spaces => 2
+rule 'MD010'
+rule 'MD011'
+rule 'MD022'
+rule 'MD023'
+rule 'MD027'
+rule 'MD031'
+rule 'MD032'
+rule 'MD040'
+rule 'MD046'


### PR DESCRIPTION
Markdownlint is a tool allowing us to check a markdown file syntax. It comes with a set of rules (40), some of them can take parameters (number of columns for example).

This PR is a proposal of 12 rules that must be matched for any markdown files in this repo.

You can find a description of each rule at <https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md>